### PR TITLE
fix: use user provided journald flags

### DIFF
--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -75,10 +75,14 @@ function setup() {
 }
 
 function defaults() {
-  if [ -z "$NUM_LINES" ]; then
+  CRICTL_FLAGS+=" --tail=${VAR_LOG_LINES}"
+  techo "Using Crictl flags: ${CRICTL_FLAGS}"
+  
+  if [ -z "$JOURNALD_FLAGS" ]; then
     JOURNALD_FLAGS+=" -n ${VAR_LOG_LINES}"
-    CRICTL_FLAGS+=" --tail=${VAR_LOG_LINES}"
     techo "No number of log lines defined for collection. Collecting last 500k log lines from journald and crictl logs"
+  else
+    techo "Using Journald flags: ${JOURNALD_FLAGS}"
   fi
 }
 


### PR DESCRIPTION
* with flags
```bash
edge-ec3738429bfb6bd418884276abdca461:~ # ./sb.sh  -s 7 -e 5
2025-05-19 20:53:36: Logging since 2025-05-12
2025-05-19 20:53:36: Logging until 2025-05-14
2025-05-19 20:53:36: Using Crictl flags:  --tail=500000
**2025-05-19 20:53:36: Using Journald flags:  --since 2025-05-12 --until 2025-05-14**
2025-05-19 20:53:36: Created temporary directory: /tmp/tmp.tmaIdkhNAl
2025-05-19 20:53:36: Collecting logs in /tmp/tmp.tmaIdkhNAl/edge-ec3738429bfb6bd418884276abdca461-2025-05-19_20_53_36
2025-05-19 20:53:36: Detecting k8s distribution
2025-05-19 20:53:36: K8s distribution detected: k3s
2025-05-19 20:53:36: Collecting system info
2025-05-19 20:53:36: Collecting network info
2025-05-19 20:53:37: Collecting logs from /var/log
2025-05-19 20:53:37: Collecting logs from journald using flags  --since 2025-05-12 --until 2025-05-14
```

* When no flags
```bash
edge-ec3738429bfb6bd418884276abdca461:~ # ./sb.sh 
2025-05-19 20:53:01: Using Crictl flags:  --tail=500000
**2025-05-19 20:53:01: No number of log lines defined for collection. Collecting last 500k log lines from journald and crictl logs**
2025-05-19 20:53:01: Created temporary directory: /tmp/tmp.7YKQv1LXab
2025-05-19 20:53:01: Collecting logs in /tmp/tmp.7YKQv1LXab/edge-ec3738429bfb6bd418884276abdca461-2025-05-19_20_53_01
2025-05-19 20:53:01: Detecting k8s distribution
2025-05-19 20:53:01: K8s distribution detected: k3s
2025-05-19 20:53:01: Collecting system info
2025-05-19 20:53:01: Collecting network info
2025-05-19 20:53:01: Collecting logs from /var/log
```
