### PR TITLE
fix check for if cluster is a pcg cluster

### DIFF
--- a/support-bundle/support-bundle-infra.sh
+++ b/support-bundle/support-bundle-infra.sh
@@ -45,7 +45,7 @@ function spectro-k8s-defaults() {
 	fi
 
 	IS_PCG_CLUSTER=false
-	if kubectl get deployment -n jet-system --output=custom-columns="Name:.metadata.name" --no-headers 2>/dev/null | grep 'spectro-cloud-driver'; then
+	if [[ "$IS_ENTERPRISE_CLUSTER" == false ]] && kubectl get deployment -n jet-system --output=custom-columns="Name:.metadata.name" --no-headers 2>/dev/null | grep 'jet'; then
 		IS_PCG_CLUSTER=true
     CLUSTER_NAME="spectro-pcg-cluster"
 		techo "This is a PCG cluster. Collecting logs from all namespaces"


### PR DESCRIPTION
Jet deployment name is `jet`.   I saw support bundle script not collecting logs from jet-system because of this issue in a new PCG.

@pavansokkenagaraj was it previously `spectro-cloud-driver`?  Should we possibly just check for both.