### PR TITLE
Fix ownership of tar file after creation

### DIFF
--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -118,7 +118,7 @@ function archive() {
   tar -czf "${TMPDIR_BASE}/${LOGNAME}.tar.gz" -C "$TMPDIR_BASE" "$LOGNAME" || {
     techo "Failed to create tar file"
   }
-
+  sudo chown "$USER:$GROUP" ${TMPDIR_BASE}/${LOGNAME}.tar.gz
   techo "Logs are archived in ${TMPDIR_BASE}/${LOGNAME}.tar.gz"
 }
 


### PR DESCRIPTION
since bash script run via sudo it create file with root:root scp does not work with copy