### PR TITLE
fix(edge-bundle): include hidden /oem entries in /oem directory

### DIFF
--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -270,7 +270,7 @@ function stylus-files() {
   techo "Collecting /oem files"
   mkdir -p $TMPDIR/oem
   ls -lah /oem/ > $TMPDIR/oem/files 2>&1
-  cp -prf /oem/* $TMPDIR/oem 2>&1
+  cp -prf /oem/. $TMPDIR/oem 2>&1
 
   techo "Collecting /run/stylus files"
   mkdir -p $TMPDIR/run/stylus


### PR DESCRIPTION
## Summary
Update `support-bundle/support-bundle-edge.sh` so the `/oem` collection step includes hidden files and directories such as `.spectrocloud`.

## Problem
The script currently copies `/oem` content with:

```bash
cp -prf /oem/* $TMPDIR/oem
```

Because `*` does not match dot-prefixed entries, hidden files and directories are omitted from the support bundle even though they appear in the `/oem/files` listing.

## Change
Replace the glob-based copy with:

```bash
cp -prf /oem/. $TMPDIR/oem
```

This preserves the existing destination layout while ensuring hidden entries are included.

## Impact
This change allows edge support bundles to include:
- `/oem/.spectrocloud`
- other hidden `/oem` entries such as `.revision` and `.stylus-state*`

## Scope
- Narrowly scoped to `/oem` collection in `stylus-files()`
- No broader changes to other copy operations in this script

## Validation

Manually verified on a airgap/local edge host where I confirmed the script collected hidden files and directory entries such as `/oem/.spectrocloud/{tui,seed,mtls}`.
