### PR TITLE
SUS-1703: rbac check on namespaces when gathering bundle

### DIFF
--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -59,6 +59,103 @@ function techo() {
   echo "$(timestamp): $*"
 }
 
+function can-list-pods-in-namespace() {
+  local NS="$1"
+  [[ "$(kubectl auth can-i list pods -n "$NS" 2>/dev/null)" == "yes" ]]
+}
+
+function rbac-error-message() {
+  local NS_LIST="$*"
+  cat <<EOF
+ERROR: Cannot list pods in namespace(s): ${NS_LIST}
+
+The user running this script does not have permission to list pods in one or
+more targeted namespaces. Support bundles require pod access for meaningful
+diagnostics.
+
+Action: Check the ClusterRole or Role attached to the user or service account
+        running this script. Ensure it grants at least 'list' (and 'get') on
+        pods in the affected namespaces, for example:
+
+          rules:
+          - apiGroups: [""]
+            resources: [pods]
+            verbs: [get, list]
+
+Exiting without creating an incomplete bundle.
+EOF
+}
+
+function validate-namespace-coverage() {
+  local -a COLLECT_NAMESPACES=()
+  local -a SKIPPED_NAMESPACES=()
+  local -a RBAC_FAILURES=()
+  local NS REASON
+
+  if ! kubectl auth can-i list namespaces >/dev/null 2>&1; then
+    techo "ERROR: Cannot list namespaces — check ClusterRole/Role attached to the user running the script."
+    techo "Action: Ensure the user can list namespaces (verbs: get, list on resource namespaces)."
+    cleanup
+    exit 1
+  fi
+
+  for NS in "${SYSTEM_NAMESPACES[@]}"; do
+    if ! kubectl get ns "$NS" >/dev/null 2>&1; then
+      SKIPPED_NAMESPACES+=("${NS}|namespace not found")
+      continue
+    fi
+
+    if ! can-list-pods-in-namespace "$NS"; then
+      RBAC_FAILURES+=("$NS")
+      continue
+    fi
+
+    COLLECT_NAMESPACES+=("$NS")
+  done
+
+  {
+    echo "Namespace Coverage Summary"
+    echo "Generated: $(timestamp)"
+    echo ""
+    printf "%-12s %-40s %s\n" "STATUS" "NAMESPACE" "NOTES"
+    printf "%-12s %-40s %s\n" "------" "---------" "-----"
+    for NS in "${COLLECT_NAMESPACES[@]}"; do
+      printf "%-12s %-40s %s\n" "COLLECT" "$NS" "accessible"
+    done
+    for ENTRY in "${SKIPPED_NAMESPACES[@]}"; do
+      NS="${ENTRY%%|*}"
+      REASON="${ENTRY#*|}"
+      printf "%-12s %-40s %s\n" "SKIP" "$NS" "$REASON"
+    done
+    for NS in "${RBAC_FAILURES[@]}"; do
+      printf "%-12s %-40s %s\n" "DENIED" "$NS" "cannot list pods (RBAC)"
+    done
+    echo ""
+    echo "Namespaces to collect: ${#COLLECT_NAMESPACES[@]}"
+    echo "Namespaces skipped:    ${#SKIPPED_NAMESPACES[@]}"
+    if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
+      echo "Namespaces denied:     ${#RBAC_FAILURES[@]}"
+    fi
+  } | tee "${TMPDIR}/namespace-coverage.txt"
+
+  techo "Namespace coverage summary written to namespace-coverage.txt"
+
+  if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
+    rbac-error-message "${RBAC_FAILURES[*]}"
+    cleanup
+    exit 1
+  fi
+
+  if [[ ${#COLLECT_NAMESPACES[@]} -eq 0 ]]; then
+    techo "ERROR: No namespaces available for collection after coverage validation."
+    techo "Action: Verify cluster access and that at least one targeted namespace exists and is accessible."
+    cleanup
+    exit 1
+  fi
+
+  SYSTEM_NAMESPACES=("${COLLECT_NAMESPACES[@]}")
+}
+
 function setup() {
   TMPDIR_BASE=$(mktemp -d $MKTEMP_BASEDIR) || { techo 'Creating temporary directory failed, please check options'; exit 1; }
   techo "Created temporary directory: $TMPDIR_BASE"
@@ -1170,6 +1267,7 @@ stylus-files
 crictl-logs
 set-kubeconfig
 spectro-k8s-defaults
+validate-namespace-coverage
 k8s-resources
 if [ "${DISTRO}" = "kubeadm" ]; then
   var-log-pods

--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -59,9 +59,19 @@ function techo() {
   echo "$(timestamp): $*"
 }
 
+function can-i-list() {
+  local RESOURCE="$1"
+  local NS="${2:-}"
+  if [[ -n "$NS" ]]; then
+    [[ "$(kubectl auth can-i list "$RESOURCE" -n "$NS" 2>/dev/null)" == "yes" ]]
+  else
+    [[ "$(kubectl auth can-i list "$RESOURCE" 2>/dev/null)" == "yes" ]]
+  fi
+}
+
 function can-list-pods-in-namespace() {
   local NS="$1"
-  [[ "$(kubectl auth can-i list pods -n "$NS" 2>/dev/null)" == "yes" ]]
+  can-i-list pods "$NS"
 }
 
 function rbac-error-message() {
@@ -86,18 +96,50 @@ Exiting without creating an incomplete bundle.
 EOF
 }
 
+function cluster-rbac-error-message() {
+  local RESOURCE_LIST="$*"
+  cat <<EOF
+ERROR: Cannot list cluster-scoped resource(s): ${RESOURCE_LIST}
+
+The user running this script does not have permission to list one or more
+cluster-scoped resources required for a complete support bundle.
+
+Action: Check the ClusterRole attached to the user or service account running
+        this script. Ensure it grants at least 'list' (and 'get') on the denied
+        resources, for example:
+
+          rules:
+          - apiGroups: [""]
+            resources: [namespaces, nodes]
+            verbs: [get, list]
+          - apiGroups: [apiextensions.k8s.io]
+            resources: [customresourcedefinitions]
+            verbs: [get, list]
+
+Exiting without creating an incomplete bundle.
+EOF
+}
+
 function validate-namespace-coverage() {
   local -a COLLECT_NAMESPACES=()
   local -a SKIPPED_NAMESPACES=()
   local -a RBAC_FAILURES=()
-  local NS REASON
+  local -a CLUSTER_RBAC_OK=()
+  local -a CLUSTER_RBAC_FAILURES=()
+  local -a REQUIRED_CLUSTER_LIST=(
+    namespaces
+    nodes
+    customresourcedefinitions.apiextensions.k8s.io
+  )
+  local NS REASON RESOURCE
 
-  if ! kubectl auth can-i list namespaces >/dev/null 2>&1; then
-    techo "ERROR: Cannot list namespaces — check ClusterRole/Role attached to the user running the script."
-    techo "Action: Ensure the user can list namespaces (verbs: get, list on resource namespaces)."
-    cleanup
-    exit 1
-  fi
+  for RESOURCE in "${REQUIRED_CLUSTER_LIST[@]}"; do
+    if can-i-list "$RESOURCE"; then
+      CLUSTER_RBAC_OK+=("$RESOURCE")
+    else
+      CLUSTER_RBAC_FAILURES+=("$RESOURCE")
+    fi
+  done
 
   for NS in "${SYSTEM_NAMESPACES[@]}"; do
     if ! kubectl get ns "$NS" >/dev/null 2>&1; then
@@ -114,9 +156,20 @@ function validate-namespace-coverage() {
   done
 
   {
-    echo "Namespace Coverage Summary"
+    echo "RBAC / Namespace Coverage Summary"
     echo "Generated: $(timestamp)"
     echo ""
+    echo "Cluster-scoped permissions"
+    printf "%-12s %-50s %s\n" "STATUS" "RESOURCE" "NOTES"
+    printf "%-12s %-50s %s\n" "------" "--------" "-----"
+    for RESOURCE in "${CLUSTER_RBAC_OK[@]}"; do
+      printf "%-12s %-50s %s\n" "ALLOWED" "$RESOURCE" "can list"
+    done
+    for RESOURCE in "${CLUSTER_RBAC_FAILURES[@]}"; do
+      printf "%-12s %-50s %s\n" "DENIED" "$RESOURCE" "cannot list (RBAC)"
+    done
+    echo ""
+    echo "Namespace coverage"
     printf "%-12s %-40s %s\n" "STATUS" "NAMESPACE" "NOTES"
     printf "%-12s %-40s %s\n" "------" "---------" "-----"
     for NS in "${COLLECT_NAMESPACES[@]}"; do
@@ -131,14 +184,22 @@ function validate-namespace-coverage() {
       printf "%-12s %-40s %s\n" "DENIED" "$NS" "cannot list pods (RBAC)"
     done
     echo ""
-    echo "Namespaces to collect: ${#COLLECT_NAMESPACES[@]}"
-    echo "Namespaces skipped:    ${#SKIPPED_NAMESPACES[@]}"
+    echo "Cluster resources allowed: ${#CLUSTER_RBAC_OK[@]}"
+    echo "Cluster resources denied:  ${#CLUSTER_RBAC_FAILURES[@]}"
+    echo "Namespaces to collect:     ${#COLLECT_NAMESPACES[@]}"
+    echo "Namespaces skipped:        ${#SKIPPED_NAMESPACES[@]}"
     if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
-      echo "Namespaces denied:     ${#RBAC_FAILURES[@]}"
+      echo "Namespaces denied:         ${#RBAC_FAILURES[@]}"
     fi
   } | tee "${TMPDIR}/namespace-coverage.txt"
 
   techo "Namespace coverage summary written to namespace-coverage.txt"
+
+  if [[ ${#CLUSTER_RBAC_FAILURES[@]} -gt 0 ]]; then
+    cluster-rbac-error-message "${CLUSTER_RBAC_FAILURES[*]}"
+    cleanup
+    exit 1
+  fi
 
   if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
     rbac-error-message "${RBAC_FAILURES[*]}"

--- a/support-bundle/support-bundle-infra.sh
+++ b/support-bundle/support-bundle-infra.sh
@@ -294,9 +294,19 @@ function techo() {
   echo "$(timestamp): $*"
 }
 
+function can-i-list() {
+  local RESOURCE="$1"
+  local NS="${2:-}"
+  if [[ -n "$NS" ]]; then
+    [[ "$(kubectl auth can-i list "$RESOURCE" -n "$NS" 2>/dev/null)" == "yes" ]]
+  else
+    [[ "$(kubectl auth can-i list "$RESOURCE" 2>/dev/null)" == "yes" ]]
+  fi
+}
+
 function can-list-pods-in-namespace() {
   local NS="$1"
-  [[ "$(kubectl auth can-i list pods -n "$NS" 2>/dev/null)" == "yes" ]]
+  can-i-list pods "$NS"
 }
 
 function rbac-error-message() {
@@ -321,18 +331,50 @@ Exiting without creating an incomplete bundle.
 EOF
 }
 
+function cluster-rbac-error-message() {
+  local RESOURCE_LIST="$*"
+  cat <<EOF
+ERROR: Cannot list cluster-scoped resource(s): ${RESOURCE_LIST}
+
+The user running this script does not have permission to list one or more
+cluster-scoped resources required for a complete support bundle.
+
+Action: Check the ClusterRole attached to the user or service account running
+        this script. Ensure it grants at least 'list' (and 'get') on the denied
+        resources, for example:
+
+          rules:
+          - apiGroups: [""]
+            resources: [namespaces, nodes]
+            verbs: [get, list]
+          - apiGroups: [apiextensions.k8s.io]
+            resources: [customresourcedefinitions]
+            verbs: [get, list]
+
+Exiting without creating an incomplete bundle.
+EOF
+}
+
 function validate-namespace-coverage() {
   local -a COLLECT_NAMESPACES=()
   local -a SKIPPED_NAMESPACES=()
   local -a RBAC_FAILURES=()
-  local NS REASON
+  local -a CLUSTER_RBAC_OK=()
+  local -a CLUSTER_RBAC_FAILURES=()
+  local -a REQUIRED_CLUSTER_LIST=(
+    namespaces
+    nodes
+    customresourcedefinitions.apiextensions.k8s.io
+  )
+  local NS REASON RESOURCE
 
-  if ! kubectl auth can-i list namespaces >/dev/null 2>&1; then
-    techo "ERROR: Cannot list namespaces — check ClusterRole/Role attached to the user running the script."
-    techo "Action: Ensure the user can list namespaces (verbs: get, list on resource namespaces)."
-    cleanup
-    exit 1
-  fi
+  for RESOURCE in "${REQUIRED_CLUSTER_LIST[@]}"; do
+    if can-i-list "$RESOURCE"; then
+      CLUSTER_RBAC_OK+=("$RESOURCE")
+    else
+      CLUSTER_RBAC_FAILURES+=("$RESOURCE")
+    fi
+  done
 
   for NS in "${SYSTEM_NAMESPACES[@]}"; do
     if ! kubectl get ns "$NS" >/dev/null 2>&1; then
@@ -349,9 +391,20 @@ function validate-namespace-coverage() {
   done
 
   {
-    echo "Namespace Coverage Summary"
+    echo "RBAC / Namespace Coverage Summary"
     echo "Generated: $(timestamp)"
     echo ""
+    echo "Cluster-scoped permissions"
+    printf "%-12s %-50s %s\n" "STATUS" "RESOURCE" "NOTES"
+    printf "%-12s %-50s %s\n" "------" "--------" "-----"
+    for RESOURCE in "${CLUSTER_RBAC_OK[@]}"; do
+      printf "%-12s %-50s %s\n" "ALLOWED" "$RESOURCE" "can list"
+    done
+    for RESOURCE in "${CLUSTER_RBAC_FAILURES[@]}"; do
+      printf "%-12s %-50s %s\n" "DENIED" "$RESOURCE" "cannot list (RBAC)"
+    done
+    echo ""
+    echo "Namespace coverage"
     printf "%-12s %-40s %s\n" "STATUS" "NAMESPACE" "NOTES"
     printf "%-12s %-40s %s\n" "------" "---------" "-----"
     for NS in "${COLLECT_NAMESPACES[@]}"; do
@@ -366,14 +419,22 @@ function validate-namespace-coverage() {
       printf "%-12s %-40s %s\n" "DENIED" "$NS" "cannot list pods (RBAC)"
     done
     echo ""
-    echo "Namespaces to collect: ${#COLLECT_NAMESPACES[@]}"
-    echo "Namespaces skipped:    ${#SKIPPED_NAMESPACES[@]}"
+    echo "Cluster resources allowed: ${#CLUSTER_RBAC_OK[@]}"
+    echo "Cluster resources denied:  ${#CLUSTER_RBAC_FAILURES[@]}"
+    echo "Namespaces to collect:     ${#COLLECT_NAMESPACES[@]}"
+    echo "Namespaces skipped:        ${#SKIPPED_NAMESPACES[@]}"
     if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
-      echo "Namespaces denied:     ${#RBAC_FAILURES[@]}"
+      echo "Namespaces denied:         ${#RBAC_FAILURES[@]}"
     fi
   } | tee "${TMPDIR}/namespace-coverage.txt"
 
   techo "Namespace coverage summary written to namespace-coverage.txt"
+
+  if [[ ${#CLUSTER_RBAC_FAILURES[@]} -gt 0 ]]; then
+    cluster-rbac-error-message "${CLUSTER_RBAC_FAILURES[*]}"
+    cleanup
+    exit 1
+  fi
 
   if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
     rbac-error-message "${RBAC_FAILURES[*]}"

--- a/support-bundle/support-bundle-infra.sh
+++ b/support-bundle/support-bundle-infra.sh
@@ -294,6 +294,103 @@ function techo() {
   echo "$(timestamp): $*"
 }
 
+function can-list-pods-in-namespace() {
+  local NS="$1"
+  [[ "$(kubectl auth can-i list pods -n "$NS" 2>/dev/null)" == "yes" ]]
+}
+
+function rbac-error-message() {
+  local NS_LIST="$*"
+  cat <<EOF
+ERROR: Cannot list pods in namespace(s): ${NS_LIST}
+
+The user running this script does not have permission to list pods in one or
+more targeted namespaces. Support bundles require pod access for meaningful
+diagnostics.
+
+Action: Check the ClusterRole or Role attached to the user or service account
+        running this script. Ensure it grants at least 'list' (and 'get') on
+        pods in the affected namespaces, for example:
+
+          rules:
+          - apiGroups: [""]
+            resources: [pods]
+            verbs: [get, list]
+
+Exiting without creating an incomplete bundle.
+EOF
+}
+
+function validate-namespace-coverage() {
+  local -a COLLECT_NAMESPACES=()
+  local -a SKIPPED_NAMESPACES=()
+  local -a RBAC_FAILURES=()
+  local NS REASON
+
+  if ! kubectl auth can-i list namespaces >/dev/null 2>&1; then
+    techo "ERROR: Cannot list namespaces — check ClusterRole/Role attached to the user running the script."
+    techo "Action: Ensure the user can list namespaces (verbs: get, list on resource namespaces)."
+    cleanup
+    exit 1
+  fi
+
+  for NS in "${SYSTEM_NAMESPACES[@]}"; do
+    if ! kubectl get ns "$NS" >/dev/null 2>&1; then
+      SKIPPED_NAMESPACES+=("${NS}|namespace not found")
+      continue
+    fi
+
+    if ! can-list-pods-in-namespace "$NS"; then
+      RBAC_FAILURES+=("$NS")
+      continue
+    fi
+
+    COLLECT_NAMESPACES+=("$NS")
+  done
+
+  {
+    echo "Namespace Coverage Summary"
+    echo "Generated: $(timestamp)"
+    echo ""
+    printf "%-12s %-40s %s\n" "STATUS" "NAMESPACE" "NOTES"
+    printf "%-12s %-40s %s\n" "------" "---------" "-----"
+    for NS in "${COLLECT_NAMESPACES[@]}"; do
+      printf "%-12s %-40s %s\n" "COLLECT" "$NS" "accessible"
+    done
+    for ENTRY in "${SKIPPED_NAMESPACES[@]}"; do
+      NS="${ENTRY%%|*}"
+      REASON="${ENTRY#*|}"
+      printf "%-12s %-40s %s\n" "SKIP" "$NS" "$REASON"
+    done
+    for NS in "${RBAC_FAILURES[@]}"; do
+      printf "%-12s %-40s %s\n" "DENIED" "$NS" "cannot list pods (RBAC)"
+    done
+    echo ""
+    echo "Namespaces to collect: ${#COLLECT_NAMESPACES[@]}"
+    echo "Namespaces skipped:    ${#SKIPPED_NAMESPACES[@]}"
+    if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
+      echo "Namespaces denied:     ${#RBAC_FAILURES[@]}"
+    fi
+  } | tee "${TMPDIR}/namespace-coverage.txt"
+
+  techo "Namespace coverage summary written to namespace-coverage.txt"
+
+  if [[ ${#RBAC_FAILURES[@]} -gt 0 ]]; then
+    rbac-error-message "${RBAC_FAILURES[*]}"
+    cleanup
+    exit 1
+  fi
+
+  if [[ ${#COLLECT_NAMESPACES[@]} -eq 0 ]]; then
+    techo "ERROR: No namespaces available for collection after coverage validation."
+    techo "Action: Verify cluster access and that at least one targeted namespace exists and is accessible."
+    cleanup
+    exit 1
+  fi
+
+  SYSTEM_NAMESPACES=("${COLLECT_NAMESPACES[@]}")
+}
+
 function setup() {
   TMPDIR_BASE=$(mktemp -d $MKTEMP_BASEDIR) || { techo 'Creating temporary directory failed, please check options'; exit 1; }
   techo "Created temporary directory: $TMPDIR_BASE"
@@ -385,6 +482,7 @@ done
 is-kubeconfig-set || { echo "KUBECONFIG is not set. Unable to collect Kubernetes logs."; cleanup; exit 1; }
 spectro-k8s-defaults
 setup
+validate-namespace-coverage
 k8s-resources
 mongo-status
 archive


### PR DESCRIPTION
The purpose of this PR is to add checks during support bundle generation in regards to ensuring the correct RBAC is in place for a user to generate a complete bundle.  These checks ensure a user can list namespaces, and also list pods within those namespaces.  If they cannot, fail fast and output relevant logs and information to stdout and also write namespace coverage summary to namespace-coverage.txt file.

Negative case screenshot:
<img width="1159" height="583" alt="Screenshot 2026-06-16 at 8 52 57 AM" src="https://github.com/user-attachments/assets/a82d0bb2-984a-4552-84c3-305941b5ece0" />

Positive case screenshot.
<img width="1325" height="342" alt="Screenshot 2026-06-16 at 8 54 39 AM" src="https://github.com/user-attachments/assets/5b5541fe-6f72-427f-9a6f-1db6c6952f53" />
