### PR TITLE
SUS-1724: Include installer and content-script logs in edge support bundle

### DIFF
--- a/support-bundle/README-edge.md
+++ b/support-bundle/README-edge.md
@@ -105,6 +105,7 @@ The script collects various types of information:
 ### Edge-specific Information
 * Stylus agent logs
 * Palette agent logs
+* Installation-time logs
 * Edge cluster configuration
 * System upgrade information
 
@@ -192,6 +193,7 @@ Output that is collected from the cluster. Note that pod logs from other nodes a
 
 * Stylus agent logs and configuration
 * Palette agent logs and status
+* Installation-time logs (collected only if present)
 * Edge cluster configuration
 * System upgrade information
 * Edge-specific custom resources

--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -384,6 +384,26 @@ function stylus-files() {
     techo "bundle-pkg index.json not found at /usr/local/spectrocloud/bundle/bundle-pkg/index.json"
   fi
 
+  # collect installer.log if exists
+  techo "Collecting installer.log if exists"
+  if [ -f "/usr/local/installer.log" ]; then
+    mkdir -p $TMPDIR/usr/local
+    cp -p "/usr/local/installer.log" "$TMPDIR/usr/local/" 2>&1
+    techo "Collected installer.log"
+  else
+    techo "installer.log not found at /usr/local/installer.log"
+  fi
+
+  # collect stylus-content-script.log if exists
+  techo "Collecting stylus-content-script.log if exists"
+  if [ -f "/usr/local/spectrocloud/stylus-content-script.log" ]; then
+    mkdir -p $TMPDIR/usr/local/spectrocloud
+    cp -p "/usr/local/spectrocloud/stylus-content-script.log" "$TMPDIR/usr/local/spectrocloud/" 2>&1
+    techo "Collected stylus-content-script.log"
+  else
+    techo "stylus-content-script.log not found at /usr/local/spectrocloud/stylus-content-script.log"
+  fi
+
   # collect containerd config.toml if exists
   techo "Collecting containerd config.toml if exists"
   if [ -f "/etc/containerd/config.toml" ]; then


### PR DESCRIPTION
Edge support bundles did not include key installation-time logs that are written during Kairos appliance install. 

This change adds copy-if-present collection of:
- `/usr/local/installer.log` — journal snapshot captured at install time 
- `/usr/local/spectrocloud/stylus-content-script.log` — output from `content.sh` during content unpack/bootstrap

Files are copied into the bundle with the same host paths (e.g. `usr/local/installer.log`) and skipped with a console message when absent.
