### PR TITLE
feat(support-bundle): collect per-pod MongoDB df in infra and edge bundles

### DIFF
--- a/support-bundle/README-edge.md
+++ b/support-bundle/README-edge.md
@@ -206,3 +206,4 @@ For Enterprise and PCG clusters, the script collects MongoDB replica set informa
 * `rs-status.json`: Replica set status including member health, sync state, and election info
 * `rs-conf.json`: Replica set configuration including member settings and priorities
 * `replication-info.txt`: Oplog information and replication window
+* `disk-usage.txt`: Actual `df -h /var/lib/mongodb` per mongo pod — the real on-disk size, which can differ from the requested PVC/PV size on thin-provisioned or fixed-disk-offering backends (e.g. CloudStack fixed offerings)

--- a/support-bundle/README-infra.md
+++ b/support-bundle/README-infra.md
@@ -150,6 +150,7 @@ For Enterprise and PCG clusters, the script collects MongoDB replica set informa
 * `rs-status.json`: Replica set status including member health, sync state, and election info
 * `rs-conf.json`: Replica set configuration including member settings and priorities
 * `replication-info.txt`: Oplog information and replication window
+* `disk-usage.txt`: Actual `df -h /var/lib/mongodb` per mongo pod — the real on-disk size, which can differ from the requested PVC/PV size on thin-provisioned or fixed-disk-offering backends (e.g. CloudStack fixed offerings)
 
 ## Important Notes
 

--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -671,6 +671,17 @@ function mongo-status() {
 
   techo "Collecting MongoDB replication info"
   kubectl exec -n hubble-system "$MONGO_POD" -c mongo -- bash -c "$MONGO_CMD $MONGO_AUTH admin --quiet --eval 'rs.printReplicationInfo()'" > "${TMPDIR}/mongo/replication-info.txt" 2>&1
+
+  techo "Collecting MongoDB per-pod disk usage (df)"
+  : > "${TMPDIR}/mongo/disk-usage.txt"
+  while IFS= read -r POD; do
+    [ -n "$POD" ] || continue
+    {
+      echo "== $POD =="
+      kubectl exec -n hubble-system "$POD" -c mongo -- df -h /var/lib/mongodb 2>&1
+      echo
+    } >> "${TMPDIR}/mongo/disk-usage.txt"
+  done < <(printf '%s\n' "$MONGO_PODS")
 }
 
 function k8s-resources() {

--- a/support-bundle/support-bundle-infra.sh
+++ b/support-bundle/support-bundle-infra.sh
@@ -181,6 +181,17 @@ function mongo-status() {
 
   techo "Collecting MongoDB replication info"
   kubectl exec -n hubble-system "$MONGO_POD" -c mongo -- bash -c "$MONGO_CMD $MONGO_AUTH admin --quiet --eval 'rs.printReplicationInfo()'" > "${TMPDIR}/mongo/replication-info.txt" 2>&1
+
+  techo "Collecting MongoDB per-pod disk usage (df)"
+  : > "${TMPDIR}/mongo/disk-usage.txt"
+  while IFS= read -r POD; do
+    [ -n "$POD" ] || continue
+    {
+      echo "== $POD =="
+      kubectl exec -n hubble-system "$POD" -c mongo -- df -h /var/lib/mongodb 2>&1
+      echo
+    } >> "${TMPDIR}/mongo/disk-usage.txt"
+  done < <(printf '%s\n' "$MONGO_PODS")
 }
 
 function k8s-resources() {


### PR DESCRIPTION
## What

Adds `df -h /var/lib/mongodb` for every mongo pod to both the **infra** and **edge** support bundles, written to `mongo/disk-usage.txt`.

## Why

The PVC/PV objects already collected under `k8s/cluster-resources` report only the **requested** size. On thin-provisioned or **fixed-disk-offering** backends (e.g. Apache CloudStack fixed offerings) the real filesystem differs from that number. `df` is the ground truth for MongoDB disk-exhaustion triage.

Motivated by [SUS-1801](https://spectrocloud.atlassian.net/browse/SUS-1801) / [SCS-4599](https://spectrocloud.atlassian.net/browse/SCS-4599): the customer's mongo PVCs showed `20Gi` while the actual disks were `50G` (CloudStack fixed offering). The mismatch was only caught via a `df` the customer pasted manually — it was **not** in the support bundle, costing a diagnosis round-trip.

## Changes

- `support-bundle-infra.sh` — `mongo-status()`: per-pod `df` loop → `mongo/disk-usage.txt`
- `support-bundle-edge.sh` — same addition (identical `mongo-status()`, kept in sync)
- `README-infra.md`, `README-edge.md` — document the new file

## Notes

- Read-only; reuses the existing `$MONGO_PODS` list, no new deps.
- Newline-safe iteration (`while IFS= read -r` + process substitution).
- `bash -n` passes on both scripts.
- A follow-up PR will add per-DB/collection size collection (the "what's eating disk" question, SCS-4625) — split out to keep this PR minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SUS-1801]: https://spectrocloud.atlassian.net/browse/SUS-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCS-4599]: https://spectrocloud.atlassian.net/browse/SCS-4599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ