### PR TITLE
feat(support-bundle): collect MongoDB per-collection sizes in infra and edge bundles

### DIFF
--- a/support-bundle/README-edge.md
+++ b/support-bundle/README-edge.md
@@ -207,3 +207,4 @@ For Enterprise and PCG clusters, the script collects MongoDB replica set informa
 * `rs-conf.json`: Replica set configuration including member settings and priorities
 * `replication-info.txt`: Oplog information and replication window
 * `disk-usage.txt`: Actual `df -h /var/lib/mongodb` per mongo pod — the real on-disk size, which can differ from the requested PVC/PV size on thin-provisioned or fixed-disk-offering backends (e.g. CloudStack fixed offerings)
+* `db-collection-sizes.txt`: Per-database and per-collection storage/data sizes (MB) and document counts — shows which collections are consuming disk

--- a/support-bundle/README-infra.md
+++ b/support-bundle/README-infra.md
@@ -151,6 +151,7 @@ For Enterprise and PCG clusters, the script collects MongoDB replica set informa
 * `rs-conf.json`: Replica set configuration including member settings and priorities
 * `replication-info.txt`: Oplog information and replication window
 * `disk-usage.txt`: Actual `df -h /var/lib/mongodb` per mongo pod — the real on-disk size, which can differ from the requested PVC/PV size on thin-provisioned or fixed-disk-offering backends (e.g. CloudStack fixed offerings)
+* `db-collection-sizes.txt`: Per-database and per-collection storage/data sizes (MB) and document counts — shows which collections are consuming disk
 
 ## Important Notes
 

--- a/support-bundle/support-bundle-edge.sh
+++ b/support-bundle/support-bundle-edge.sh
@@ -682,6 +682,17 @@ function mongo-status() {
       echo
     } >> "${TMPDIR}/mongo/disk-usage.txt"
   done < <(printf '%s\n' "$MONGO_PODS")
+
+  techo "Collecting MongoDB database + collection sizes"
+  kubectl exec -n hubble-system "$MONGO_POD" -c mongo -- bash -c "$MONGO_CMD $MONGO_AUTH admin --quiet --eval '
+    db.adminCommand({listDatabases:1}).databases.forEach(function(d){
+      var s = db.getSiblingDB(d.name).stats(1024*1024);
+      print(\"DB \"+d.name+\" storageSize(MB)=\"+s.storageSize+\" dataSize(MB)=\"+s.dataSize);
+      db.getSiblingDB(d.name).getCollectionNames().forEach(function(c){
+        var cs = db.getSiblingDB(d.name).getCollection(c).stats(1024*1024);
+        print(\"  \"+d.name+\".\"+c+\" storageSize(MB)=\"+cs.storageSize+\" size(MB)=\"+cs.size+\" count=\"+cs.count);
+      });
+    });'" > "${TMPDIR}/mongo/db-collection-sizes.txt" 2>&1
 }
 
 function k8s-resources() {

--- a/support-bundle/support-bundle-infra.sh
+++ b/support-bundle/support-bundle-infra.sh
@@ -192,6 +192,17 @@ function mongo-status() {
       echo
     } >> "${TMPDIR}/mongo/disk-usage.txt"
   done < <(printf '%s\n' "$MONGO_PODS")
+
+  techo "Collecting MongoDB database + collection sizes"
+  kubectl exec -n hubble-system "$MONGO_POD" -c mongo -- bash -c "$MONGO_CMD $MONGO_AUTH admin --quiet --eval '
+    db.adminCommand({listDatabases:1}).databases.forEach(function(d){
+      var s = db.getSiblingDB(d.name).stats(1024*1024);
+      print(\"DB \"+d.name+\" storageSize(MB)=\"+s.storageSize+\" dataSize(MB)=\"+s.dataSize);
+      db.getSiblingDB(d.name).getCollectionNames().forEach(function(c){
+        var cs = db.getSiblingDB(d.name).getCollection(c).stats(1024*1024);
+        print(\"  \"+d.name+\".\"+c+\" storageSize(MB)=\"+cs.storageSize+\" size(MB)=\"+cs.size+\" count=\"+cs.count);
+      });
+    });'" > "${TMPDIR}/mongo/db-collection-sizes.txt" 2>&1
 }
 
 function k8s-resources() {


### PR DESCRIPTION
## What

Adds per-database and per-collection storage/data sizes (MB) and document counts to both the **infra** and **edge** support bundles, written to `mongo/db-collection-sizes.txt`.

## Why

The bundle already captures replica-set status, config, and replication info — but nothing about **what** is consuming MongoDB disk. When a self-hosted Palette cluster hits storage pressure, the recurring triage question is *which collection is bloated* (component events, audits, metrics, cluster summaries, etc.). This collector answers it directly from the bundle.

Follow-up to #34 (per-pod `df`); motivated by [SCS-4625](https://spectrocloud.atlassian.net/browse/SCS-4625) / [SUS-1801](https://spectrocloud.atlassian.net/browse/SUS-1801).

## Changes

- `support-bundle-infra.sh` / `support-bundle-edge.sh` — `mongo-status()`: `listDatabases` + `db.stats()` / `collection.stats()` → `mongo/db-collection-sizes.txt`
- `README-infra.md`, `README-edge.md` — document the new file

## Notes

- Read-only; reuses the existing `$MONGO_POD` / `$MONGO_CMD` / `$MONGO_AUTH` and the same `bash -c "… --eval '…'"` pattern as the existing collectors.
- `bash -n` passes on both scripts.
- Independent of #34 (per-pod df) — different output file, no overlap; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCS-4625]: https://spectrocloud.atlassian.net/browse/SCS-4625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUS-1801]: https://spectrocloud.atlassian.net/browse/SUS-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ